### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/boriltampan/cd743a3f-f1d3-4586-b397-693d8cf4157e/5f640032-f067-4124-80a6-b4946d8fa9bb/_apis/work/boardbadge/2dc0f11a-7f08-4418-94e9-e2c648ea2ed3)](https://dev.azure.com/boriltampan/cd743a3f-f1d3-4586-b397-693d8cf4157e/_boards/board/t/5f640032-f067-4124-80a6-b4946d8fa9bb/Microsoft.RequirementCategory)
 # Delbert
 0k


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/boriltampan/cd743a3f-f1d3-4586-b397-693d8cf4157e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.